### PR TITLE
Break long words in operator shelf listing page (bug 1106098)

### DIFF
--- a/src/media/css/shelf-listing.styl
+++ b/src/media/css/shelf-listing.styl
@@ -44,7 +44,8 @@
         a.shelf {
             display: block;
             min-height: 52px;
-            padding: 10px 10px 10px 52px;
+            padding: 10px 85px 10px 52px;
+            word-break: break-all;
             
             &:hover {
                 background: #F5F5F5;


### PR DESCRIPTION
Before: http://screencast.com/t/eiytNhQg

After:

![screen shot 2014-12-01 at 10 57 06 am](https://cloud.githubusercontent.com/assets/23885/5251284/f3fcd2e4-7948-11e4-8fea-4969e8ec2d7c.png)
