### PR TITLE
Use v2 search endpoint for operator dashboard (bug 1136460)

### DIFF
--- a/src/media/js/routes_api.js
+++ b/src/media/js/routes_api.js
@@ -9,7 +9,7 @@ define('routes_api', [], function() {
         'fxa-login': '/api/v2/account/fxa-login/',
         'login': '/api/v2/account/login/',
         'logout': '/api/v2/account/logout/',
-        'search': '/api/v1/apps/search/non-public/?cache=1&vary=0',
+        'search': '/api/v2/apps/search/non-public/?cache=1&vary=0',
         'site-config': '/api/v2/services/config/site/?serializer=commonplace',
         'permissions': '/api/v2/account/operators/',
         'feed-shelves': '/api/v2/feed/shelves/',


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1136460

**We weren't really using the endpoint to search for non-public apps**. This endpoint only exists in v2 on zamboni, but this didn't 404 because the v1 search endpoint regexp in zamboni didn't end with a `$`, so we were really querying the public search endpoint... This will be fixed by https://github.com/mozilla/zamboni/pull/2958